### PR TITLE
Fix composer 2 compatibilit issue

### DIFF
--- a/src/Client/Exception/InvalidApiResponseException.php
+++ b/src/Client/Exception/InvalidApiResponseException.php
@@ -5,7 +5,7 @@
  * @copyright (c) Emico B.V. 2017
  */
 
-namespace Emico\RobinHqLib\Client;
+namespace Emico\RobinHqLib\Client\Exception;
 
 use Exception;
 

--- a/src/Client/RobinClient.php
+++ b/src/Client/RobinClient.php
@@ -7,6 +7,7 @@
 namespace Emico\RobinHqLib\Client;
 
 
+use Emico\RobinHqLib\Client\Exception\InvalidApiResponseException;
 use Emico\RobinHqLib\Config\Config;
 use Emico\RobinHqLib\Config\ConfigInterface;
 use Emico\RobinHqLib\Model\Collection;


### PR DESCRIPTION
With Composer 1 this would already throw a warning:

```
Deprecation Notice: Class Emico\RobinHqLib\Client\InvalidApiResponseException located in ./vendor/emico/robinhq-lib/src/Client/Exception/InvalidApiResponseException.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/rutger/bin/composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201
```

When installed via Composer 2 it would say

```
Class Emico\RobinHqLib\Client\InvalidApiResponseException located in ./vendor/emico/robinhq-lib/src/Client/Exception/InvalidApiResponseException.php does not comply with psr-4 autoloading standard. Skipping.
```