### PR TITLE
Fix: PHP 8.1 JsonSerializable compatibility

### DIFF
--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -55,6 +55,7 @@ class Collection implements JsonSerializable, \Countable
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         if ($this->key !== null) {

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -236,7 +236,7 @@ class Customer implements JsonSerializable
      * @since 5.4.0
      */
     #[\ReturnTypeWillChange]
-    function jsonSerialize()
+    public function jsonSerialize()
     {
         $data = [
             'email_address' => $this->emailAddress,

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -235,6 +235,7 @@ class Customer implements JsonSerializable
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
+    #[\ReturnTypeWillChange]
     function jsonSerialize()
     {
         $data = [

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -321,6 +321,7 @@ class Order implements \JsonSerializable
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/src/Model/Order/DetailsView.php
+++ b/src/Model/Order/DetailsView.php
@@ -106,6 +106,7 @@ class DetailsView implements JsonSerializable
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = ['display_as' => $this->displayAs];

--- a/src/Model/SearchResult.php
+++ b/src/Model/SearchResult.php
@@ -39,6 +39,7 @@ class SearchResult implements \JsonSerializable
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
Using `#[\ReturnTypeWillChange]` to omit the deprecation notice in PHP 8.1