### PR TITLE
fix: PHP 8.1 compatibility with \Countable

### DIFF
--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -43,7 +43,7 @@ class Collection implements JsonSerializable, \Countable
     /**
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->elements);
     }


### PR DESCRIPTION
Add return type for `\Countable::count()` for PHP 8.1 compatibility (does NOT break earlier PHP versions)