### PR TITLE
php8.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "license": "OSL-3.0",
   "description": "Robin HQ library",
   "require": {
-    "php": ">=7.4 <8.2",
+    "php": ">=7.4 <=8.2",
     "guzzlehttp/guzzle": "^7.4",
     "psr/log": "~1.0",
     "psr/container": "~1.0",


### PR DESCRIPTION
I just run some phpcs tests to check if the code is compatible with 8.2 and it all passes. So if you can accept this PR and tag a new version, I can also update the magento2 robinhq module. If the new versions stays in the 2.0 range the Magento2RobinHq module does not need a version update in the require section of the composer.json. See also: https://github.com/EmicoEcommerce/Magento2RobinHq/pull/51