### PR TITLE
PHP 8.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "license": "OSL-3.0",
   "description": "Robin HQ library",
   "require": {
-    "php": ">=8.0 <=8.3",
+    "php": ">=8.0 <=8.4",
     "guzzlehttp/guzzle": "^7.4",
     "psr/log": "*",
     "psr/container": "^1.0|^2.0",

--- a/src/Client/RobinClient.php
+++ b/src/Client/RobinClient.php
@@ -14,6 +14,7 @@ use Emico\RobinHqLib\Model\Collection;
 use Emico\RobinHqLib\Model\Customer;
 use Emico\RobinHqLib\Model\Order;
 use GuzzleHttp\Client;
+use GuzzleHttp\Utils;
 use JsonSerializable;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
@@ -112,7 +113,7 @@ class RobinClient
      */
     protected function post(string $path, $payload): ResponseInterface
     {
-        $this->logger->debug('Payload: ' . \GuzzleHttp\json_encode($payload));
+        $this->logger->debug('Payload: ' . Utils::jsonEncode($payload));
 
         $response = $this->httpClient->post($path, [
             'auth' => [ $this->config->getApiKey(), $this->config->getApiSecret() ],

--- a/src/Client/RobinClientFactory.php
+++ b/src/Client/RobinClientFactory.php
@@ -8,7 +8,6 @@ namespace Emico\RobinHqLib\Client;
 
 
 use Emico\RobinHqLib\Config\Config;
-use GuzzleHttp\Client;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -10,7 +10,7 @@ namespace Emico\RobinHqLib\Config;
 class Config implements ConfigInterface
 {
     /** Date format to use in json serialization */
-    const JSON_DATE_FORMAT = DATE_ATOM;
+    const JSON_DATE_FORMAT = DATE_ISO8601;
 
     /**
      * @var bool

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -10,7 +10,7 @@ namespace Emico\RobinHqLib\Config;
 class Config implements ConfigInterface
 {
     /** Date format to use in json serialization */
-    const JSON_DATE_FORMAT = DATE_ISO8601;
+    const JSON_DATE_FORMAT = DATE_ATOM;
 
     /**
      * @var bool

--- a/src/EventProcessor/CustomerEventProcessor.php
+++ b/src/EventProcessor/CustomerEventProcessor.php
@@ -8,6 +8,7 @@ namespace Emico\RobinHqLib\EventProcessor;
 
 
 use Emico\RobinHqLib\Client\RobinClient;
+use Emico\RobinHqLib\Event\CustomerEvent;
 use Emico\RobinHqLib\Event\EventInterface;
 
 class CustomerEventProcessor implements EventProcessorInterface
@@ -21,7 +22,7 @@ class CustomerEventProcessor implements EventProcessorInterface
     }
 
     /**
-     * @param EventInterface $event
+     * @param EventInterface|CustomerEvent $event
      * @return bool
      */
     public function processEvent(EventInterface $event): bool

--- a/src/EventProcessor/CustomerEventProcessor.php
+++ b/src/EventProcessor/CustomerEventProcessor.php
@@ -8,10 +8,7 @@ namespace Emico\RobinHqLib\EventProcessor;
 
 
 use Emico\RobinHqLib\Client\RobinClient;
-use Emico\RobinHqLib\Event\CustomerEvent;
 use Emico\RobinHqLib\Event\EventInterface;
-use Exception;
-use Psr\Log\LoggerInterface;
 
 class CustomerEventProcessor implements EventProcessorInterface
 {
@@ -24,7 +21,7 @@ class CustomerEventProcessor implements EventProcessorInterface
     }
 
     /**
-     * @param EventInterface|CustomerEvent $event
+     * @param EventInterface $event
      * @return bool
      */
     public function processEvent(EventInterface $event): bool

--- a/src/EventProcessor/CustomerEventProcessorFactory.php
+++ b/src/EventProcessor/CustomerEventProcessorFactory.php
@@ -8,11 +8,9 @@ namespace Emico\RobinHqLib\EventProcessor;
 
 
 use Emico\RobinHqLib\Client\RobinClient;
-use Emico\RobinHqLib\Queue\EventInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use Psr\Log\LoggerInterface;
 
 class CustomerEventProcessorFactory
 {

--- a/src/EventProcessor/OrderEventProcessor.php
+++ b/src/EventProcessor/OrderEventProcessor.php
@@ -9,8 +9,6 @@ namespace Emico\RobinHqLib\EventProcessor;
 
 use Emico\RobinHqLib\Client\RobinClient;
 use Emico\RobinHqLib\Event\EventInterface;
-use Emico\RobinHqLib\Event\OrderEvent;
-use Psr\Log\LoggerInterface;
 
 class OrderEventProcessor implements EventProcessorInterface
 {
@@ -23,7 +21,7 @@ class OrderEventProcessor implements EventProcessorInterface
     }
 
     /**
-     * @param EventInterface|OrderEvent $event
+     * @param EventInterface $event
      * @return bool
      */
     public function processEvent(EventInterface $event): bool

--- a/src/EventProcessor/OrderEventProcessor.php
+++ b/src/EventProcessor/OrderEventProcessor.php
@@ -9,6 +9,7 @@ namespace Emico\RobinHqLib\EventProcessor;
 
 use Emico\RobinHqLib\Client\RobinClient;
 use Emico\RobinHqLib\Event\EventInterface;
+use Emico\RobinHqLib\Event\OrderEvent;
 
 class OrderEventProcessor implements EventProcessorInterface
 {
@@ -21,7 +22,7 @@ class OrderEventProcessor implements EventProcessorInterface
     }
 
     /**
-     * @param EventInterface $event
+     * @param EventInterface|OrderEvent $event
      * @return bool
      */
     public function processEvent(EventInterface $event): bool

--- a/src/Model/Collection.php
+++ b/src/Model/Collection.php
@@ -24,7 +24,7 @@ class Collection implements JsonSerializable, \Countable
     /**
      * Collection constructor.
      * @param array $elements
-     * @param string $key
+     * @param null|string $key
      */
     public function __construct(array $elements, string $key = null)
     {

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -241,7 +241,7 @@ class Customer implements JsonSerializable
             'email_address' => $this->emailAddress,
             'name' => $this->name,
             'phone_number' => $this->phoneNumber,
-            'customer_since' => $this->customerSince ? $this->customerSince->format(DateTimeInterface::ATOM) : '',
+            'customer_since' => $this->customerSince ? $this->customerSince->format(\DateTimeInterface::ISO8601) : '',
             'order_count' => $this->orderCount,
             'total_revenue' => $this->totalRevenue,
             'total_spent' => (string) $this->totalRevenue,

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -6,7 +6,6 @@
 
 namespace Emico\RobinHqLib\Model;
 
-use DateTime;
 use DateTimeInterface;
 use Emico\RobinHqLib\Config\Config;
 use JsonSerializable;
@@ -242,7 +241,7 @@ class Customer implements JsonSerializable
             'email_address' => $this->emailAddress,
             'name' => $this->name,
             'phone_number' => $this->phoneNumber,
-            'customer_since' => $this->customerSince ? $this->customerSince->format(DateTime::ISO8601) : '',
+            'customer_since' => $this->customerSince ? $this->customerSince->format(DateTimeInterface::ATOM) : '',
             'order_count' => $this->orderCount,
             'total_revenue' => $this->totalRevenue,
             'total_spent' => (string) $this->totalRevenue,

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -7,11 +7,9 @@
 namespace Emico\RobinHqLib\Model;
 
 
-use DateTime;
 use DateTimeInterface;
 use Emico\RobinHqLib\Config\Config;
 use Emico\RobinHqLib\Model\Order\DetailsView;
-use PhpOffice\PhpSpreadsheet\Shared\Date;
 
 class Order implements \JsonSerializable
 {

--- a/src/Model/Order/DetailsView.php
+++ b/src/Model/Order/DetailsView.php
@@ -7,7 +7,6 @@
 namespace Emico\RobinHqLib\Model\Order;
 
 use DateTimeInterface;
-use Emico\RobinHqLib\Config\Config;
 use JsonSerializable;
 
 class DetailsView implements JsonSerializable

--- a/src/Model/SearchResult.php
+++ b/src/Model/SearchResult.php
@@ -7,9 +7,6 @@
 namespace Emico\RobinHqLib\Model;
 
 
-use DateTime;
-use DateTimeInterface;
-
 class SearchResult implements \JsonSerializable
 {
     /**

--- a/src/Queue/FileQueueFactory.php
+++ b/src/Queue/FileQueueFactory.php
@@ -22,12 +22,10 @@ class FileQueueFactory
      */
     public function __invoke(ContainerInterface $container): FileQueue
     {
-        $queue = new FileQueue(
+        return new FileQueue(
             __DIR__ . '/../../var/queue',
             $container->get(EventProcessingService::class),
             $container->get(LoggerInterface::class)
         );
-
-        return $queue;
     }
 }

--- a/src/Queue/QueueInterface.php
+++ b/src/Queue/QueueInterface.php
@@ -7,13 +7,11 @@
 namespace Emico\RobinHqLib\Queue;
 
 
-use Emico\RobinHqLib\Service\EventProcessingService;
-
 interface QueueInterface
 {
     /**
-     * @param string $event
+     * @param string $serializedEvent
      * @return bool
      */
-    public function pushEvent(string $event): bool;
+    public function pushEvent(string $serializedEvent): bool;
 }

--- a/src/Server/RestApiServer.php
+++ b/src/Server/RestApiServer.php
@@ -12,9 +12,9 @@ use Emico\RobinHqLib\DataProvider\DataProviderInterface;
 use Emico\RobinHqLib\DataProvider\Exception\DataNotFoundException;
 use Emico\RobinHqLib\DataProvider\Exception\InvalidRequestException;
 use Exception;
+use Laminas\Diactoros\Response\JsonResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Laminas\Diactoros\Response\JsonResponse;
 
 class RestApiServer
 {
@@ -71,7 +71,7 @@ class RestApiServer
         /* If using PHP in CGI mode. */
         if (isset($serverParams['HTTP_AUTHORIZATION'])) {
             if (preg_match("/Basic\s+(.*)$/i", $serverParams['HTTP_AUTHORIZATION'], $matches)) {
-                list($user, $password) = explode(':', base64_decode($matches[1]), 2);
+                [$user, $password] = explode(':', base64_decode($matches[1]), 2);
             }
         } else {
             if (isset($serverParams["PHP_AUTH_USER"])) {

--- a/src/Service/CustomerServiceFactory.php
+++ b/src/Service/CustomerServiceFactory.php
@@ -7,16 +7,10 @@
 namespace Emico\RobinHqLib\Service;
 
 
-use Emico\RobinHqLib\Client\RobinClient;
-use Emico\RobinHqLib\EventProcessor\CustomerEventProcessor;
-use Emico\RobinHqLib\EventProcessor\OrderEventProcessor;
 use Emico\RobinHqLib\Queue\QueueInterface;
-use Emico\RobinHqLib\Queue\Serializer\EventSerializer;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 class CustomerServiceFactory
 {

--- a/src/Service/EventProcessingService.php
+++ b/src/Service/EventProcessingService.php
@@ -7,7 +7,6 @@
 namespace Emico\RobinHqLib\Service;
 
 
-use Emico\RobinHqLib\Client\RobinClient;
 use Emico\RobinHqLib\Event\EventInterface;
 use Emico\RobinHqLib\EventProcessor\EventProcessorInterface;
 use Emico\RobinHqLib\Queue\Serializer\EventSerializer;

--- a/src/Service/OrderService.php
+++ b/src/Service/OrderService.php
@@ -14,16 +14,13 @@ use Emico\RobinHqLib\Queue\Serializer\EventSerializer;
 
 class OrderService
 {
-    private EventSerializer $eventSerializer;
-
     /**
      * CustomerService constructor.
-     * @param QueueInterface $queue
      */
-    public function __construct(private QueueInterface $queue)
-    {
-        $this->eventSerializer = new EventSerializer();
-    }
+    public function __construct(
+        private QueueInterface $queue,
+        private EventSerializer $eventSerializer,
+    ) {}
 
     /**
      * @param Order $order

--- a/src/Service/OrderService.php
+++ b/src/Service/OrderService.php
@@ -22,7 +22,6 @@ class OrderService
      */
     public function __construct(private QueueInterface $queue)
     {
-        $this->queue = $queue;
         $this->eventSerializer = new EventSerializer();
     }
 


### PR DESCRIPTION
Hi,

I've bumped the required PHP version so 8.3 is included in the scope and ran static code analysis. Since there are no noteworthy errors, I've taken the liberty to clean up some of the code which was mostly unused imports and deprecations.

Something which might need attention is the change for `DateTime::ISO8601`. This has been deprecated since PHP 7.2. According to the docs this has been superseded by `DateTimeInterface::ATOM`.